### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'therubyracer'
 gem "blacklight_advanced_search"
 gem "blacklight_range_limit"
 gem "blacklight_more_like_this"
-gem "bundle"
+gem "bundler"
 # Use unicorn as the web server
 # gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,8 +57,6 @@ GEM
       rails (~> 3.0)
     blankslate (2.1.2.4)
     builder (3.0.0)
-    bundle (0.0.1)
-      bundler
     chunky_png (1.2.5)
     coffee-rails (3.1.1)
       coffee-script (>= 2.2.0)
@@ -173,7 +171,7 @@ DEPENDENCIES
   blacklight_advanced_search
   blacklight_more_like_this
   blacklight_range_limit
-  bundle
+  bundler
   coffee-rails (~> 3.1.0)
   devise
   execjs


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock